### PR TITLE
implement nim-sys queue for 'least

### DIFF
--- a/httpleast.nim
+++ b/httpleast.nim
@@ -1,12 +1,24 @@
 import std/strutils
-import std/os
-import std/net
-import std/nativesockets
-import std/posix
 
 import pkg/cps
 
 import httpleast/eventqueue
+
+when leastQueue == "nim-sys":
+  import sys/sockets
+
+  type
+    Client = AsyncConn[TCP]
+    ClientAddr = IP4Endpoint
+else:
+  import std/nativesockets
+  import std/net
+  import std/os
+  import std/posix
+
+  type
+    Client = SocketHandle
+    ClientAddr = string
 
 const
   leastPort {.intdefine.} = 8080
@@ -14,12 +26,13 @@ const
   leastKeepAlive {.booldefine.} = true
   leastDelay {.intdefine.} = 0
 
-template errorHandler(e: OSErrorCode; s: string) =
-  case e.cint
-  of {EAGAIN, EWOULDBLOCK}:  # it's the same picture
-    continue
-  else:
-    raiseOSError e: s
+when leastQueue != "nim-sys":
+  template errorHandler(e: OSErrorCode; s: string) =
+    case e.cint
+    of {EAGAIN, EWOULDBLOCK}:  # it's the same picture
+      continue
+    else:
+      raiseOSError e: s
 
 template happyPath(op: untyped; logic: untyped): untyped {.dirty.} =
   ## do a read or write and handle the result, else run logic.
@@ -27,7 +40,10 @@ template happyPath(op: untyped; logic: untyped): untyped {.dirty.} =
   let girth {.inject.} = op
   case girth
   of -1: # error
-    errorHandler osLastError(): "i/o error in whassup"
+    when leastQueue != "nim-sys":
+      errorHandler osLastError(): "i/o error in whassup"
+    else:
+      doAssert false, "unreachable"
   of 0: # disconnect
     break goodbye
   else:
@@ -39,7 +55,7 @@ let reply =
   else:
     "HTTP/1.1 200 ok\c\lContent-length: 13\c\lContent-Type: text/plain\c\lConnection: close\c\l\c\lHello, World!"
 
-proc whassup(client: SocketHandle; address: string) {.cps: Cont.} =
+proc whassup(client: Client; address: ClientAddr) {.cps: Cont.} =
   ## greet a client and find out what the fuck they want
   var buffer: array[256, char]      # an extra alloc is death
   var pos: int
@@ -60,10 +76,16 @@ proc whassup(client: SocketHandle; address: string) {.cps: Cont.} =
       setLen received, 0
       pos = 0
       while true:
-        # wait for the client to send us something
-        client.iowait {Read}
+        when leastQueue != "nim-sys":
+          # wait for the client to send us something
+          client.iowait {Read}
         # see what the client has to say for themselves
-        happyPath read(client.cint, addr buffer[0], sizeof buffer):
+        happyPath do:
+          when leastQueue != "nim-sys":
+            read(client.cint, addr buffer[0], sizeof buffer)
+          else:
+            read(client, cast[ptr UncheckedArray[byte]](addr buffer[0]), sizeof buffer)
+        do:
           # make an efficient copy of the buffer into the received string
           setLen(received, pos + girth)
           copyMem(addr received[pos], addr buffer[0], girth)
@@ -84,9 +106,16 @@ proc whassup(client: SocketHandle; address: string) {.cps: Cont.} =
       ##
       pos = 0
       while true:
-        # wait until we can send a reply
-        client.iowait {Write}
-        happyPath write(client.cint, unsafeAddr reply[pos], reply.len - pos):
+        when leastQueue != "nim-sys":
+          # wait until we can send a reply
+          client.iowait {Write}
+
+        happyPath do:
+          when leastQueue != "nim-sys":
+            write(client.cint, unsafeAddr reply[pos], reply.len - pos)
+          else:
+            write(client, cast[ptr UncheckedArray[byte]](unsafeAddr reply[pos]), reply.len - pos)
+        do:
           pos += girth
           if pos == reply.len:
             break
@@ -97,32 +126,43 @@ proc whassup(client: SocketHandle; address: string) {.cps: Cont.} =
 
   close client
 
-proc server(sock: SocketHandle) {.cps: Cont.} =
-  sock.persist {Read}
-  while true:
-    # the socket is ready; compose a client
-    let (client, address) = accept sock
-    if client == osInvalidSocket:
-      raiseOsError osLastError()
-    else:
+when leastQueue != "nim-sys":
+  proc server(sock: SocketHandle) {.cps: Cont.} =
+    sock.persist {Read}
+    while true:
+      # the socket is ready; compose a client
+      let (client, address) = accept sock
+      if client == osInvalidSocket:
+        raiseOsError osLastError()
+      else:
+        # spawn a continuation for the client
+        spawn: whelp whassup(client, address)
+
+      # wait for the socket to be readable
+      dismiss()
+else:
+  proc server() {.cps: Cont.} =
+    let sock = listenTcpAsync(leastAddress, leastPort.Port)
+    while true:
+      let (client, address) = accept sock
       # spawn a continuation for the client
       spawn: whelp whassup(client, address)
 
-    # wait for the socket to be readable
-    dismiss()
-
 proc serve() {.nimcall.} =
   ## listen for connections on the `address` and `port`
-  var socket = newSocket()
-  socket.setSockOpt(OptReusePort, true)
-  socket.setSockOpt(OptReuseAddr, true)
-  socket.bindAddr(leastPort.Port, leastAddress)
-  listen socket
-  let fd = getFd socket
-  setBlocking(fd, false)
+  when leastQueue != "nim-sys":
+    var socket = newSocket()
+    socket.setSockOpt(OptReusePort, true)
+    socket.setSockOpt(OptReuseAddr, true)
+    socket.bindAddr(leastPort.Port, leastAddress)
+    listen socket
+    let fd = getFd socket
+    setBlocking(fd, false)
 
-  # spawn the server continuation
-  spawn: whelp server(fd)
+    # spawn the server continuation
+    spawn: whelp server(fd)
+  else:
+    spawn: whelp server()
 
   # run until there are no more continuations
   run()

--- a/httpleast.nim
+++ b/httpleast.nim
@@ -23,7 +23,7 @@ else:
 
 const
   leastPort {.intdefine.} = 8080
-  leastAddress {.strdefine.} = "127.1"
+  leastAddress {.strdefine.} = "localhost"
   leastKeepAlive {.booldefine.} = true
   leastDelay {.intdefine.} = 0
 

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,3 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
+requires "https://github.com/alaviss/nim-sys#features/sockets"

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys#f50a94794c285ca066081b844d5de91a875d79de"
+requires "https://github.com/alaviss/nim-sys == 0.0.1"

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys#390556b7d2ed8e8295fc51ad54f43c110fad2266"
+requires "https://github.com/alaviss/nim-sys#d0ad678569955c5db8ece8f3e4ff6888abbaaa8b"

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys#e96c36e58e01ae7ff75efbf7547cc1ebe0d46f8e"
+requires "https://github.com/alaviss/nim-sys#390556b7d2ed8e8295fc51ad54f43c110fad2266"

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys#features/sockets"
+requires "https://github.com/alaviss/nim-sys#e96c36e58e01ae7ff75efbf7547cc1ebe0d46f8e"

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys#d0ad678569955c5db8ece8f3e4ff6888abbaaa8b"
+requires "https://github.com/alaviss/nim-sys#f50a94794c285ca066081b844d5de91a875d79de"

--- a/httpleast/eventqueue.nim
+++ b/httpleast/eventqueue.nim
@@ -1,7 +1,6 @@
 import std/strutils
 import std/macros
 import std/os
-import std/selectors
 import std/monotimes
 import std/nativesockets
 import std/tables
@@ -10,8 +9,6 @@ import std/deques
 
 import cps
 
-export Event
-
 const
   leastDebug {.booldefine, used.} = false   ## emit extra debugging output
   leastPoolSize {.intdefine, used.} = 64    ## expected pending continuations
@@ -19,6 +16,15 @@ const
   threaded* = compileOption"threads"
   leastRecycle {.booldefine, used.} = false ## recycle continuations
   leastQueue* {.strdefine, used.} = "none"
+
+when leastQueue == "nim-sys":
+  import sys/ioqueue
+
+  export Event
+else:
+  import std/selectors
+
+  export Event
 
 type
   Clock = MonoTime
@@ -79,6 +85,18 @@ when threaded:
     proc initQueue(q: var ContQueue) =
       q = true
 
+  elif leastQueue == "nim-sys":
+    import std/options
+    import sys/ioqueue
+
+    type ContQueue = bool
+
+    proc needsInit(q: var ContQueue): bool =
+      q == false
+
+    proc initQueue(q: var ContQueue) =
+      q = true
+
   type QueueThread = Thread[ContQueue]
 
 type
@@ -90,10 +108,13 @@ type
 
   EventQueue = object
     state: Readiness              ## dispatcher readiness
-    selector: Selector[Cont]      ## watches selectable stuff
+    when leastQueue != "nim-sys":
+      selector: Selector[Cont]      ## watches selectable stuff
+      waiters: int                  ## a count of selector listeners
+      serverFd: Fd                  ## server's persistent file-descriptor
+    else:
+      runnable: seq[Continuation] ## continuations from sys/ioqueue ready to run
     yields: Deque[Cont]           ## continuations ready to run
-    waiters: int                  ## a count of selector listeners
-    serverFd: Fd                  ## server's persistent file-descriptor
     when threaded:
       queue: ContQueue
       threads: seq[QueueThread]
@@ -113,7 +134,12 @@ proc `==`(a, b: Fd): bool {.borrow, used.}
 
 proc len*(eq: EventQueue): int =
   ## The number of pending continuations.
-  eq.waiters + eq.yields.len
+  when leastQueue != "nim-sys":
+    eq.waiters + eq.yields.len
+  else:
+    # ioqueue does not expose "number of waiters", so emulate it by counting a
+    # running queue as 1 waiter.
+    ord(ioqueue.running()) + eq.yields.len
 
 when leastRecycle:
   when threaded and leastQueue == "loony":
@@ -135,9 +161,10 @@ when leastRecycle:
 proc init() {.inline.} =
   ## initialize the event queue to prepare it for requests
   if eq.state == Unready:
-    eq.serverFd = invalidFd
-    eq.selector = newSelector[Cont]()
-    eq.waiters = 0
+    when leastQueue != "nim-sys":
+      eq.serverFd = invalidFd
+      eq.selector = newSelector[Cont]()
+      eq.waiters = 0
 
     when threaded:
       if eq.queue.needsInit:
@@ -157,28 +184,33 @@ proc init() {.inline.} =
           discard
         elif leastQueue == "none":
           discard
+        elif leastQueue == "nim-sys":
+          discard
 
     eq.state = Stopped
 
 proc stop*() =
   ## Tell the dispatcher to stop, discarding all pending continuations.
-  if eq.state == Running:
-    eq.state = Stopping
+  when leastQueue != "nim-sys":
+    if eq.state == Running:
+      eq.state = Stopping
 
-    # discard the current selector to dismiss any pending events
-    close eq.selector
+      # discard the current selector to dismiss any pending events
+      close eq.selector
 
-    when leastQueue == "taskpools":
-      if not eq.queue.needsInit:
-        shutdown eq.queue
-        eq.queue = nil
-    elif leastQueue == "none":
-      if not eq.queue.needsInit:
-        eq.queue = false
+      when leastQueue == "taskpools":
+        if not eq.queue.needsInit:
+          shutdown eq.queue
+          eq.queue = nil
+      elif leastQueue == "none":
+        if not eq.queue.needsInit:
+          eq.queue = false
 
-    # re-initialize the queue
-    eq.state = Unready
-    init()
+      # re-initialize the queue
+      eq.state = Unready
+      init()
+  else:
+    raise newException(Defect, "nim-sys does not support stopping the queue")
 
 proc trampoline*(c: sink Cont) {.inline.} =
   ## Run the supplied continuation until it is complete.
@@ -197,37 +229,53 @@ proc trampoline*(c: sink Cont) {.inline.} =
 proc manic(timeout = 0): int {.inline.} =
   if eq.state != Running: return 0
 
-  if eq.waiters > 0:
-    when leastDebug:
-      let clock = now()
+  when leastQueue != "nim-sys":
+    if eq.waiters > 0:
+      when leastDebug:
+        let clock = now()
 
-    # ready holds the ready file descriptors and their events.
-    let ready = select(eq.selector, timeout)
-    for event in ready.items:
-      # see if this is the server's listening socket
-      let isServer = eq.serverFd == Fd(event.fd)
+      # ready holds the ready file descriptors and their events.
+      let ready = select(eq.selector, timeout)
+      for event in ready.items:
+        # see if this is the server's listening socket
+        let isServer = eq.serverFd == Fd(event.fd)
 
-      # retrieve the continuation from the selector
-      var cont = getData(eq.selector, event.fd)
+        # retrieve the continuation from the selector
+        var cont = getData(eq.selector, event.fd)
 
-      if not isServer:
-        # stop listening on this fd
-        unregister(eq.selector, event.fd)
-        dec eq.waiters
-        when leastDebug:
-          cont.clock = clock
-          cont.delay = now() - clock
-          cont.fd = event.fd.Fd
-          debug "💈delay", cont.delay
+        if not isServer:
+          # stop listening on this fd
+          unregister(eq.selector, event.fd)
+          dec eq.waiters
+          when leastDebug:
+            cont.clock = clock
+            cont.delay = now() - clock
+            cont.fd = event.fd.Fd
+            debug "💈delay", cont.delay
 
-      # add to the deque of ready-to-run continuations
-      eq.yields.addLast cont
+        # add to the deque of ready-to-run continuations
+        eq.yields.addLast cont
+  else:
+    if ioqueue.running():
+      eq.runnable.setLen(0)
+
+      poll(eq.runnable):
+        if timeout < 0:
+          none Duration
+        else:
+          some initDuration(milliseconds = timeout)
 
   # run any ready continuations
   while eq.yields.len > 0:
     inc result
     trampoline:
       popFirst eq.yields
+
+  when leastQueue == "nim-sys":
+    while eq.runnable.len > 0:
+      let cont = pop eq.runnable
+      inc result
+      discard trampoline cont
 
 proc run*(interval: Duration = DurationZero) =
   ## The dispatcher runs with a maximal polling interval; an `interval` of
@@ -252,6 +300,9 @@ proc run*(interval: Duration = DurationZero) =
     elif leastQueue == "none":
       if not eq.queue.needsInit:
         eq.queue = false
+    elif leastQueue == "nim-sys":
+      if not eq.queue.needsInit:
+        eq.queue = false
 
 proc spawn*(c: sink Cont) {.inline.} =
   ## Queue the supplied continuation `c`; control remains in the calling
@@ -269,6 +320,9 @@ proc spawn*(c: sink Cont) {.inline.} =
         elif leastQueue == "none":
           addLast(eq.yields, c)
           break done
+        elif leastQueue == "nim-sys":
+          addLast(eq.yields, c)
+          break done
 
     # else, spawn to the local eventqueue
     addLast(eq.yields, c)
@@ -277,28 +331,40 @@ proc iowait*(c: sink Cont; file: int | SocketHandle;
              events: set[Event]): Cont {.cpsMagic.} =
   ## Continue upon any of `events` on the given file-descriptor or
   ## SocketHandle.
-  if events.len > 0:
-    if eq.serverFd.int != file.int:
-      registerHandle(eq.selector, file, events = events, data = c)
-      inc eq.waiters
-      debug "📂file", $Fd(file)
+  when leastQueue == "nim-sys":
+    # While supported by ioqueue, httpleast should not have to use this function at all
+    raise newException(Defect, "iowait() shouldn't be used")
+  else:
+    if events.len > 0:
+      if eq.serverFd.int != file.int:
+        registerHandle(eq.selector, file, events = events, data = c)
+        inc eq.waiters
+        debug "📂file", $Fd(file)
 
 proc persist*(c: sink Cont; file: int | SocketHandle;
               events: set[Event]): Cont {.cpsMagic.} =
   ## Let the event queue know you want long-running registrations.
-  assert eq.serverFd == invalidFd, "call persist only once"
-  result = iowait(c, file, events)
-  eq.serverFd = Fd(file)
+  when leastQueue == "nim-sys":
+    # ioqueue does not support this feature
+    raise newException(Defect, "persist() is not supported")
+  else:
+    assert eq.serverFd == invalidFd, "call persist only once"
+    result = iowait(c, file, events)
+    eq.serverFd = Fd(file)
 
 proc delay*(c: sink Cont; ms: Natural): Cont {.cpsMagic.} =
   ## Do nothing for `ms` milliseconds before continuing.
-  if ms < 1:
-    result = c
+  when leastQueue == "nim-sys":
+    # ioqueue does not support this feature yet
+    raise newException(Defect, "delay() is not supported")
   else:
-    registerTimer(eq.selector, timeout = ms,
-                  oneshot = true, data = c)
-    inc eq.waiters
-    debug "💤sleep", $ms
+    if ms < 1:
+      result = c
+    else:
+      registerTimer(eq.selector, timeout = ms,
+                    oneshot = true, data = c)
+      inc eq.waiters
+      debug "💤sleep", $ms
 
 when threaded and leastQueue == "loony":
   proc consumer(q: ContQueue) {.thread.} =


### PR DESCRIPTION
Rough port of httpleast to nim-sys

Can be tested with `-d:leastQueue=nim-sys`, ~~does not support multi-threading~~.

~~Marked as draft until `sys/sockets` reach `master`.~~ Released as 0.0.1.

Current numbers: https://pasty.ee/qORTSAAaclWq

Note: ioqueue mode currently requires a fix in `nim-sys`