### PR TITLE
update to nim-sys 0.0.3

### DIFF
--- a/httpleast.nim
+++ b/httpleast.nim
@@ -10,7 +10,7 @@ when leastQueue == "nim-sys":
 
   type
     Client = AsyncConn[TCP]
-    ClientAddr = IP4Endpoint
+    ClientAddr = IPEndpoint
 else:
   import std/nativesockets
   import std/net

--- a/httpleast.nimble
+++ b/httpleast.nimble
@@ -5,4 +5,4 @@ license = "MIT"
 
 requires "https://github.com/nim-works/cps > 0.4.0 & < 1.0.0"
 requires "https://github.com/nim-works/loony >= 0.1.5 & < 1.0.0"
-requires "https://github.com/alaviss/nim-sys == 0.0.1"
+requires "https://github.com/alaviss/nim-sys == 0.0.3"


### PR DESCRIPTION
This introduced IPv6 support, so least will now prefer to bind to IPv6 if leastAddress resolves to an IPv6 address.

This should also fix @disruptek's resolver issues