### PR TITLE
eventqueue: run continuations from ioqueue first

### DIFF
--- a/httpleast/eventqueue.nim
+++ b/httpleast/eventqueue.nim
@@ -268,11 +268,6 @@ proc manic(timeout = 0): int {.inline.} =
           some initDuration(milliseconds = timeout)
 
   # run any ready continuations
-  while eq.yields.len > 0:
-    inc result
-    trampoline:
-      popFirst eq.yields
-
   when leastQueue == "nim-sys" or leastQueue == "ioqueue":
     while eq.runnable.len > 0:
       let cont = pop eq.runnable
@@ -282,6 +277,11 @@ proc manic(timeout = 0): int {.inline.} =
         trampoline Cont(cont)
       else:
         discard trampoline cont
+
+  while eq.yields.len > 0:
+    inc result
+    trampoline:
+      popFirst eq.yields
 
 proc run*(interval: Duration = DurationZero) =
   ## The dispatcher runs with a maximal polling interval; an `interval` of


### PR DESCRIPTION
This fixes a bug where the server will hang with one connection.

This is due to continuations from ioqueue queues extra continuations
 that must be run before the next poll() and we didn't run them.

Reorder the runs to solve this problem.